### PR TITLE
chore: bump urdf-loader to 0.12.7

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "urdf-loader",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "urdf-loader",
-      "version": "0.12.6",
+      "version": "0.12.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.21.8",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picknikrobotics/urdf-loader",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "URDF Loader for THREE.js and webcomponent viewer",
   "main": "src/URDFLoader.js",
   "type": "module",


### PR DESCRIPTION
Bumps the PickNik-scoped JavaScript package version after the collision-node loadMeshCb change landed on master.

Validation:
- npm ci
- npm run lint
- npm run build
- npm test